### PR TITLE
change doctype to scrbook, add hypersetup, remove old bf commands

### DIFF
--- a/Thesis.tex
+++ b/Thesis.tex
@@ -14,11 +14,15 @@
 %             2013/03/08	(Soren Ebbesen)
 %             2014/03/13	(Soren Ebbesen)
 % ______________________________________________________________________________
-\documentclass[10pt,twoside,a4paper,fleqn]{report}
+% \documentclass[10pt,twoside,a4paper,fleqn]{report}
+\documentclass[10pt,twoside,a4paper,fleqn]{scrbook}
 
 %custom commands for comments of Supervisor (sv), phd candidate(pc)
-\newcommand{\sv}[1]{\textcolor{red}{{\bf SV:}~#1}}    
-\newcommand{\pc}[1]{\textcolor{cyan}{{\bf PC:}~#1}} 
+\newcommand{\sv}[1]{\textcolor{red}{{\textbf{SV:}}~#1}}    
+\newcommand{\pc}[1]{\textcolor{cyan}{{\textbf{PC:}}~#1}} 
+
+% text color
+\usepackage[svgnames,x11names,table]{xcolor}
 
 \usepackage[english,mt]{ethidsc} % Special IDSC styles and commands      	
 								 % {german}/english: language of headings, etc.
@@ -31,8 +35,6 @@
 \usepackage{multirow}
 % Allow for a new line in the same cell of a table (https://tex.stackexchange.com/questions/2441/how-to-add-a-forced-line-break-inside-a-table-cell/19678)
 \usepackage{makecell}
-% text color
-\usepackage{xcolor}
 % forests (used to represent classes in the code)
 \usepackage[edges]{forest}
 % forests (attempt II)
@@ -41,6 +43,19 @@
 \usepackage{acronym}
 % to include a pdf with the title page
 \usepackage{pdfpages}
+
+\hypersetup{ 	
+pdfsubject = {Thesis},
+pdftitle = {},
+pdfauthor = {},
+colorlinks=true,
+urlcolor=DarkBlue,
+linkcolor=DarkBlue,
+citecolor=DarkBlue,
+filecolor=DarkBlue,
+pdfborder={0 0 0}
+}
+
 
 \usetikzlibrary{arrows.meta}
 \forestset{

--- a/ethidsc.sty
+++ b/ethidsc.sty
@@ -98,7 +98,7 @@
 \newcommand{\@declaration}{}
 \newcommand{\declaration}{\gdef\@declaration{
 \ifingerman
-{\bf Erkl\"{a}rung betreffend Plagiaten: \\[1ex]}
+{\textbf{Erkl\"{a}rung betreffend Plagiaten:} \\[1ex]}
 \ifstudentB
 Wir erkl\"{a}ren hiermit mit unserer Unterschrift, das Merkblatt Eigenst\"{a}ndigkeitserkl\"{a}rung zur Kenntnis genommen, die vorliegende Arbeit selbst\"{a}ndig verfasst und die im betroffenen Fachgebiet \"{u}blichen Zitiervorschriften eingehalten zu haben.\\[3ex]
 \else
@@ -112,7 +112,7 @@ Z\"{u}rich, \the\day. \the\month. \the\year: \hrulefill
 
 \else
 
-{\bf Statement regarding plagiarism: \\[1ex]}
+{\textbf{Statement regarding plagiarism:} \\[1ex]}
 \ifstudentB
 By signing this statement, we affirm that we have read and signed the Declaration of Originality, independently produced this paper, and adhered to the general practice of source citation in this subject-area.\\[3ex]
 \else
@@ -160,18 +160,18 @@ Zurich, \the\day. \the\month. \the\year \\ %: \hrulefill
 {\large \@studentA\if\@studentB\else \ \& \@studentB\fi}
 \vspace{1.5cm}
 
-{\Huge \bf \@title \par}
+{\Huge \textbf{\@title} \par}
 \vspace{2.5cm} 
 
-{\large \bf Ph.D. Thesis}\\[3ex]
+{\large \textbf{Ph.D. Thesis}}\\[3ex]
  Institute of Neuroinformatics \\
- University of Zurich and Swiss Federal Institute of Technology\\
+ University of Zurich and ETH Zurich\\
 \vspace{3.5cm}
 
 \ifingerman
- {\bf Betreuung} \\[1.5ex]
+ \textbf{Betreuung} \\[1.5ex]
 \else
- {\bf Supervision} \\[1.5ex]
+ \textbf{Supervision} \\[1.5ex]
 \fi
 \@supervision
 
@@ -211,40 +211,40 @@ Institute of Neuroinformatics\\
 \vspace{1.5cm}
 
 \ifingerman
-{\bf Titel der Arbeit: \\[1ex]}
+{\textbf{Titel der Arbeit:} \\[1ex]}
 {\LARGE \@title \\[1ex] \par}
 \else
-{\bf Title of work: \\[1ex]}
+{\textbf{Title of work:} \\[1ex]}
 {\LARGE \@title \\[1ex] \par}
 \fi
 
 \ifingerman
-{\bf Art der Arbeit und Datum: \\[1ex]}
+{\textbf{Art der Arbeit und Datum:} \\[1ex]}
 \@type, \@date\\[2.5ex]
 %\ifst
 %Semesterarbeit, \@date\\[2.5ex]
 %\else
 %Masterarbeit, \@date\\[2.5ex]
 %\fi
-{\bf Betreuung: \\[1ex]}
+{\textbf{Betreuung:} \\[1ex]}
 \@supervision
 \else
-{\bf Thesis type and date: \\[1ex]}
+{\textbf{Thesis type and date:} \\[1ex]}
 Ph.D. Thesis, \@date\\[2.5ex]
 %\ifst
 %Semester thesis, \@date\\[2.5ex]
 %\else
 %Master thesis, \@date\\[2.5ex]
 %\fi
-{\bf Supervision: \\[1ex]}
+{\textbf{Supervision:} \\[1ex]}
 \@supervision
 \fi
 \vspace{1cm}
 
 \ifingerman
-{\bf \ifstudentB Studenten:\else Student: \fi}
+{\ifstudentB \textbf{Studenten:}\else \textbf{Student:} \fi}
 \else
-{\bf \ifstudentB Students:\else Student: \fi}
+{\ifstudentB \textbf{Students:}\else \textbf{Student:} \fi}
 \fi
 \begin{tabbing}
 \hspace*{3cm}  \= \kill


### PR DESCRIPTION
- changed doctype to scrbook as the style of headings is nicer and it might be better suited for a thesis
- scrbook is not compatible with the old \bf commands, so I changed them to \textbf
- hypersetup to remove red boxes in the ToC and format links more nicely
- "ETH Zurich" instead of "Swiss Federal Institute of Technology" on titlepage